### PR TITLE
fixes # 7 Radio buttons for roles fixed

### DIFF
--- a/Areas/Identity/Pages/Account/Register.cshtml
+++ b/Areas/Identity/Pages/Account/Register.cshtml
@@ -44,13 +44,9 @@
             @if(User.IsInRole(SD.ManagerUser ))
             {
                  <div class= "form-group row">
-                     <div class="col-2">
-                     </div>
-                     <div class="col-5">
-                        <input type ="radio" name ="rdUserRole" value = @SD.ManagerUser checked> Admin
-                        <input type ="radio" name ="rdUserRole" value = @SD.SellerUser checked> Seller
+                        <input type ="radio" name ="rdUserRole" value = @SD.ManagerUser checked> Admin &nbsp;
+                        <input type ="radio" name ="rdUserRole" value = @SD.SellerUser checked> Seller &nbsp;
                         <input type ="radio" name ="rdUserRole" value = @SD.CustomerUser checked> Regular User
-                     </div>
                  </div>
             }
             <button type="submit" class="btn btn-primary">Register</button>


### PR DESCRIPTION
fixes # 7 
In the registration of the admin page, the radio buttons for roles now appear in a row instead of piled up in a corner of the view