### PR TITLE
Fixes #39 - Adding Details for the sell notificaiton

### DIFF
--- a/Areas/Common/Controllers/NotificationController.cs
+++ b/Areas/Common/Controllers/NotificationController.cs
@@ -120,7 +120,6 @@ namespace ISProject.Controllers
                         Seen = n.Seen,
                         SendToUser = n.SendToUser,
                         OrderDetails = n.OrderDetails,
-                        OrderDetailsID = n.OrderDetailsID,
                     };
                     nvm.NotiSell.Add(ns);
                     n.Seen = true;
@@ -248,6 +247,32 @@ namespace ISProject.Controllers
                 .FirstOrDefaultAsync();
             
             return View(noti_buy);
+        }
+
+        public async Task<IActionResult> SellDetails(int id)
+        {
+            var noti_sell = await _db.NotiSell
+                .Where(n=> n.Id == id )
+                .Include(n=> n.OrderDetails)
+                .FirstOrDefaultAsync();
+            
+            var headerID = noti_sell.OrderDetails[0].OrderId;
+            var header = await _db.OrderHeader
+                .Where(h => h.Id == headerID)
+                .Include(h => h.User)
+                .FirstOrDefaultAsync();
+            
+            noti_sell.OrderDetails[0].OrderHeader = header;
+
+            foreach(var od in noti_sell.OrderDetails)
+            {
+                var product_sale = await _db.ProductSale
+                    .Where(ps => ps.Id == od.ProductId)
+                    .FirstOrDefaultAsync();
+                od.ProductSale = product_sale;
+            }
+
+            return View(noti_sell);
         }
 
         public async Task<IActionResult> AcceptRequest(int id){

--- a/Areas/Common/Views/Notification/Index.cshtml
+++ b/Areas/Common/Views/Notification/Index.cshtml
@@ -164,12 +164,19 @@
                     <p>@Html.Raw(item.Message)</p>
                 </div>
                 <div class="row col-12 text-justify">
-                    <p>Total earned: $@((item.OrderDetails.Price * item.OrderDetails.Price).ToString("F2"))</p>
+
+                    @{ var total = 0.0; }
+                    @foreach(var od in item.OrderDetails)
+                    {  
+                        total += od.Price * od.Count; 
+                    }
+                    <p>Total earned: $@(total.ToString("F2"))</p>
+                
                 </div>
 
                 <div class="col-md-3 col-sm-12 offset-md-9 text-center">
                     @* <a asp-action="BuyDetails" class="btn btn-success form-control" asp-route-id="@item.Id">See complete Order</a>  *@
-                     <a href="#" class="btn btn-success form-control">See complete Order</a>
+                     <a asp-action="SellDetails" asp-route-id="@item.Id" class="btn btn-success form-control">See complete Order</a>
                 </div>
                 
                 

--- a/Areas/Common/Views/Notification/SellDetails.cshtml
+++ b/Areas/Common/Views/Notification/SellDetails.cshtml
@@ -1,0 +1,81 @@
+﻿@model ISProject.Models.NotiSell
+@{
+    ViewData["Title"] = "Sells Details";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+
+
+<div class="col-12">
+    <div class="col-8 offset-2">
+        <div class="row">
+            <div class="col-5">
+                <h4 class="d-flex justify-content-between align-items-center mb-3">
+                    <span class="text-info">Purchase Details:</span>
+                </h4>
+            </div>
+            <div class="col-7 text-right">
+                <a asp-action="Index" asp-route-noti_type="NotiSell" class="btn btn-primary">Back</a>
+            </div>
+        </div>
+        <ul class="list-group mb-3">
+             
+            <li class="list-group-item d-flex justify-content-between">
+                <div>
+                    <h6 class="my-0">Date: </h6>
+                    <small>@Model.NotiDate</small><br>
+                    @* <small class="text-muted">Price: @Html.DisplayFor(modelItem => item.Price)</small> *@
+                </div>
+            </li>
+            
+            <li class="list-group-item d-flex justify-content-between">
+                <div>
+                    <h6 class="my-0">User who bought: </h6>
+                    <small>@Model.OrderDetails[0].OrderHeader.User.Name</small><br>
+                    @* <small class="text-muted">Price: @Html.DisplayFor(modelItem => item.Price)</small> *@
+                </div>
+            </li>
+
+        </ul>
+    </div>
+</div>
+
+
+
+
+<div class="col-12">
+    <div class="col-8 offset-2">
+        <div class="row">
+            <div class="col-5">
+                <h4 class="d-flex justify-content-between align-items-center mb-3">
+                    <span class="text-info">Products List:</span>
+                </h4>
+            </div>
+        </div>
+
+        <ul class="list-group mb-3">
+            @{ var total = 0.0; }
+           
+
+
+            @foreach(var item in Model.OrderDetails)
+            {
+                <li class="list-group-item d-flex justify-content-between">
+                    <div>
+                        <h6 class="my-0">@item.Name</h6>
+                        <small class="text-muted">Quantity: @item.Count</small><br>
+                        <small class="text-muted">Price: @Html.DisplayFor(modelItem => item.Price)</small><br>
+                        <small class="text-muted">Items remaining to this date: @item.ProductSale.Units</small>
+                    </div>
+                    <span class="text-muted">$@((item.Price * item.Count).ToString("F2"))</span>
+                    @{total += item.Price * item.Count; }
+                </li>
+            }
+            <li class="list-group-item d-flex justify-content-between bg-light">
+                <small class="text-info">Total (USD)</small>
+                <strong class="text-info">@(total.ToString("F2"))</strong>
+            </li>
+        </ul>
+    </div>
+</div>
+

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -38,6 +38,11 @@ namespace ISProject.Data
                 .HasMany(n => n.OrderDetails)
                 .WithOne()
                 .OnDelete(DeleteBehavior.SetNull);
+            
+            modelBuilder.Entity<NotiSell>()
+                .HasMany(n => n.OrderDetails)
+                .WithOne()
+                .OnDelete(DeleteBehavior.SetNull);
 
 
 
@@ -55,7 +60,7 @@ namespace ISProject.Data
                 //Seeding 10 seller
                 RegisterSeller(modelBuilder, (i*10 + 2).ToString(), SD.SellerUser, "Seller" +i.ToString() );
 
-                // //Seeding 10 products sales
+                //Seeding 10 products sales
                 modelBuilder.Entity<ProductSale>()
                     .HasData(new ProductSale()
                         {Id= i *1000 + 3, 
@@ -64,6 +69,7 @@ namespace ISProject.Data
                         Units= i + 1,
                         Price = (i + 15) / 2
                     });
+                
                 
                 //Seeding Notifications of Role Upgrade
                 if(i%3 ==0){
@@ -79,6 +85,17 @@ namespace ISProject.Data
 
                 
             }
+
+            //Adding just one more product sale, Seller 8 is selling product 1
+            modelBuilder.Entity<ProductSale>()
+                    .HasData(new ProductSale()
+                        {Id= 8 *10000 + 3, 
+                        ProductId= 1*10,
+                        SellerId=(8*10 + 2).ToString(),
+                        Units= 8 + 1,
+                        Price = (8 + 15) / 2
+                    });
+
             //Defining Roles
             string [] roles = {SD.CustomerUser,SD.ManagerUser,SD.SellerUser};
             foreach(var role in roles){    

--- a/Models/NotiSell.cs
+++ b/Models/NotiSell.cs
@@ -4,7 +4,8 @@ namespace ISProject.Models
 {
     public class NotiSell : Notification
     {
-        public int OrderDetailsID { get; set; }
-        public OrderDetails OrderDetails { get; set; }
+         public List<OrderDetails> OrderDetails { get; set; }
+        
+       
     }
 }

--- a/Utils/NotiAPI.cs
+++ b/Utils/NotiAPI.cs
@@ -87,21 +87,43 @@ namespace ISProject.Utils
             if(date ==null)
                 date = DateTime.Now;
             
+            Dictionary<string, List<OrderDetails> > sells_by_user = new Dictionary<string, List<OrderDetails>>();
+
+
             foreach(var od in orderDetails){
                 var seller = od.ProductSale.Seller;
+                var id = seller.Id;
+                List<OrderDetails> sell_list;
+                if(sells_by_user.TryGetValue(id,out sell_list) ){
+                    sell_list.Add(od);
+                }
+                else{
+                    sell_list = new List<OrderDetails>();
+                    sell_list.Add(od);
+                    sells_by_user.Add(id,sell_list);
+                }
+
+            }
+
+            foreach(var (sellerID,sell_list) in sells_by_user){
+                
+                var message = "You have sold " + sell_list[0].Count + " Unit(s) of " + sell_list[0].Name;
+                if(sell_list.Count > 1){
+                    message = "You have sold multiple products to a user, check the details for more information";
+                }
+
                 var noti_sell = new NotiSell()
                 {
-                    SendToUser = seller.Id,
+                    SendToUser = sellerID,
                     NotiDate = (DateTime)date,
-                    Message = "You have sold " + od.Count + " Unit(s) of " + od.Name,
+                    Message = message,
                     Seen = false,
-                    OrderDetails=od,
-                    OrderDetailsID = od.Id,
+                    OrderDetails=sell_list,
                 };
                 await db.NotiSell.AddAsync(noti_sell);
                 await db.SaveChangesAsync();
 
-            }
+            }  
             
             return true;
             


### PR DESCRIPTION
Fixes #39 :

- Sellers can now view the details of a sale they made. If they made a sale of more than one product at the same time, all the products are listed. The seller can also see the date of purchase and the user who made it.

- In the data seed, it was added that seller 8 sells products 8 and 1 for testing purposes.

- Some modifications to the NotiSell model and the API were necessary.